### PR TITLE
Fix AWS BucketObject notification issue

### DIFF
--- a/aws/events.ts
+++ b/aws/events.ts
@@ -13,8 +13,6 @@ export interface EventsArgs {
 }
 
 export class AwsEvents extends pulumi.ComponentResource {
-    public bucketObjectSubscription: aws.s3.BucketEventSubscription | undefined;
-
     constructor(name: string, args: EventsArgs, opts?: pulumi.ComponentResourceOptions) {
         super("aws:events", name, undefined, opts);
 
@@ -29,7 +27,7 @@ export class AwsEvents extends pulumi.ComponentResource {
             return;
         }
 
-        this.bucketObjectSubscription = args.bucket.onObjectCreated("fah-object-created", handler.callbackFunction, undefined, { parent: this });
+        args.bucket.onObjectCreated("fah-object-created", handler.callbackFunction, undefined, { parent: this });
 
         const instanceRunningEvent = new aws.cloudwatch.EventRule(`${name}-inst-running`, {
             description: "Event rule for Spot Instance request fulfillment.",

--- a/spotInstance.ts
+++ b/spotInstance.ts
@@ -190,15 +190,34 @@ export class SpotInstance extends pulumi.ComponentResource {
             zipFileName,
         }, { dependsOn: ec2SpotInstance, parent: this });
 
-        if (!events.bucketObjectSubscription) {
-            return;
-        }
-        const bucketObject = new aws.s3.BucketObject("fah-scripts", {
-            bucket: bucket,
-            key: zipFileName,
-            serverSideEncryption: "AES256",
-            source: new pulumi.asset.FileArchive("./scripts")
-        }, { parent: this, dependsOn: events.bucketObjectSubscription });
+        // Create the BucketObject just before we exit the process, because the BucketNotification
+        // resource itself is created on process exit. If we didn't do this, the BucketObject
+        // will always be created _before_ the BucketNotification exists and therefore, there wouldn't
+        // be anything to handle the notification. With this trick, we are delaying the creation of the
+        // BucketObject to after the BucketNotification is created, which itself is created via a process
+        // `beforeExit` handler.
+        // See https://github.com/pulumi/pulumi-aws/blob/master/sdk/nodejs/s3/s3Mixins.ts#L187.
+        const bucketObjectOpts: pulumi.CustomResourceOptions = {
+            parent: this,
+            dependsOn: events,
+        };
+        // Use a flag to indicate that the BucketObject resource was already created.
+        // Otherwise, when we enter the handler for the `beforeExit` event, we will
+        // once again try to create the same resource because `beforeExit` would be invoked
+        // anytime the Node process queue empties-out.
+        let bucketObjectCreated = false;
+        process.on("beforeExit", () => {
+            if (bucketObjectCreated) {
+                return;
+            }
+            const bucketObject = new aws.s3.BucketObject("fah-scripts", {
+                bucket: bucket,
+                key: zipFileName,
+                serverSideEncryption: "AES256",
+                source: new pulumi.asset.FileArchive("./scripts")
+            }, bucketObjectOpts);
+            bucketObjectCreated = true;
+        });
 
         this.objectStorage = bucket.bucket;
         this.spotRequestId = ec2SpotInstance.spotRequest?.id;


### PR DESCRIPTION
Create the BucketObject by listening to the Node process' `beforeExit` event. This event handler is added _after_ the `onObjectCreated` bucket event handler is added by Pulumi. This is because Pulumi itself uses `beforeExit` to actually hook-up the `BucketNotification` resource to the `Bucket` resource which is what tells AWS S3 about a bucket's event listeners.

Since Node will simply enqueue listeners for the `beforeExit` event and will call them in an event loop, we just need to ensure that the `BucketObject` is created in a `beforeExit` handler _after_ Pulumi's use of the same event hook.